### PR TITLE
Create element provide target option

### DIFF
--- a/src/action-systems/dom-actions.js
+++ b/src/action-systems/dom-actions.js
@@ -138,7 +138,7 @@ export class DomActions {
     }
 
     /**
-     * Create a dom element and append it to a defined parent
+     * Create a dom element and optionally append it to a defined parent or set it on a target
      * @returns {Promise<HTMLElement>}
      */
     static async create_element(step, context, process, item) {
@@ -181,6 +181,10 @@ export class DomActions {
                     args: args
                 }, context, process, item)
             }
+        }
+
+        if (step.args.target != null) {
+            await crs.process.setValue(step.args.target, element, context, process, item);
         }
 
         parentElement?.appendChild(element);

--- a/test/action-systems-tests/dom-actions.test.js
+++ b/test/action-systems-tests/dom-actions.test.js
@@ -1,0 +1,22 @@
+import {loadBinding} from "../mockups/crsbinding.mock";
+import {ElementMock} from "../mockups/element.mock";
+
+beforeAll(async () => {
+    await loadBinding();
+    await import("./../../src/index.js");
+});
+
+test("DomActions - create element target supplied", async () => {
+    const context = {}
+
+    await globalThis.crs.intent.dom.perform({
+        action: "create_element",
+        args: {
+            target: "$context.myElement",
+            tagName: "div"
+        }
+    }, context);
+
+    expect(context.myElement).not.toBeNull();
+    expect(context.myElement).toBeInstanceOf<ElementMock>(ElementMock);
+})

--- a/test/action-systems-tests/dom-actions.test.js
+++ b/test/action-systems-tests/dom-actions.test.js
@@ -13,10 +13,19 @@ test("DomActions - create element target supplied", async () => {
         action: "create_element",
         args: {
             target: "$context.myElement",
-            tagName: "div"
+            tagName: "div",
+            children: [
+                {
+                    tagName: "div",
+                    attributes: {
+                        "id": "childDiv"
+                    }
+                }
+            ]
         }
     }, context);
 
     expect(context.myElement).not.toBeNull();
     expect(context.myElement).toBeInstanceOf<ElementMock>(ElementMock);
+    expect(context.myElement.children).toHaveLength(1);
 })

--- a/test/mockups/crsbinding.mock.js
+++ b/test/mockups/crsbinding.mock.js
@@ -1,7 +1,10 @@
 import {DocumentMock} from "./dom-mock.js";
 
 export async function loadBinding() {
-    globalThis.HTMLElement = (await import("./element.mock.js")).ElementMock;
+    const elementMock = (await import("./element.mock.js")).ElementMock;
+    globalThis.HTMLElement = elementMock;
+    globalThis.DocumentFragment = elementMock;
+
     globalThis.customElements = {
         define: () => {return null}
     }


### PR DESCRIPTION
Add the ability to specify a target for create_element in the case where you have no parent